### PR TITLE
Don't require gulp as a global module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You will need `node` (`brew install node` or https://nodejs.org/en/) and `npm` (
 git clone https://github.com/simpulton/eggly-redux.git
 cd eggly-redux
 npm i
-npm run start
+npm start
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ You will need `node` (`brew install node` or https://nodejs.org/en/) and `npm` (
 git clone https://github.com/simpulton/eggly-redux.git
 cd eggly-redux
 npm i
-gulp
+npm run start
 ```
-  
+
 ## Testing
 To run the tests, run `npm test` or `karma start`.
 

--- a/client/app/components/categories/bookmarks/bookmarks.reducers.js
+++ b/client/app/components/categories/bookmarks/bookmarks.reducers.js
@@ -8,7 +8,7 @@ let bookmarks = (state = [], {type, payload}) => {
       return [ ...state, payload ];
     case 'EDIT_BOOKMARK':
       return state.map(bookmark => {
-        return bookmark.id === payload.id ? clone(payload) : bookmark;
+        return bookmark.id === payload.id ? payload : bookmark;
       });
     case 'DELETE_BOOKMARK':
       return reject(state, (b) => {
@@ -22,7 +22,7 @@ let bookmarks = (state = [], {type, payload}) => {
 
 const initialBookmark = { id: null, title: '', url: '', category: null };
 
-let bookmark = (state = clone(initialBookmark), {type, payload}) => {
+let bookmark = (state = initialBookmark, {type, payload}) => {
   switch (type) {
     case 'GET_SELECTED_BOOKMARK':
       return payload || state;

--- a/package.json
+++ b/package.json
@@ -66,12 +66,10 @@
     "url": "http://onehungrymind.com/",
     "email": "simpul@gmail.com"
   },
-  "contributors": [
-    {
+  "contributors": [{
       "name": "Jonathan Garvey",
       "url": "https://github.com/jdgarvey",
       "email": "jon.d.garvey@gmail.com"
-    }
-  ],
+  }],
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
     "email": "simpul@gmail.com"
   },
   "contributors": [{
-      "name": "Jonathan Garvey",
-      "url": "https://github.com/jdgarvey",
-      "email": "jon.d.garvey@gmail.com"
+    "name": "Jonathan Garvey",
+    "url": "https://github.com/jdgarvey",
+    "email": "jon.d.garvey@gmail.com"
   }],
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "yargs": "^3.9.0"
   },
   "scripts": {
-    "test": "karma start"
+    "test": "karma start",
+    "start": "gulp"
   },
   "keywords": [
     "angular",
@@ -65,10 +66,12 @@
     "url": "http://onehungrymind.com/",
     "email": "simpul@gmail.com"
   },
-  "contributors": [{
-    "name": "Jonathan Garvey",
-    "url": "https://github.com/jdgarvey",
-    "email": "jon.d.garvey@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Jonathan Garvey",
+      "url": "https://github.com/jdgarvey",
+      "email": "jon.d.garvey@gmail.com"
+    }
+  ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
IMO it's better to not have Gulp as a global dependency. Will prevent version issues and it's just one extra step someone has to do. You already have gulp as a local dependency so might as well take advantage of npm scripts.
